### PR TITLE
Plainly Invoke `python`

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
 
                 while (blah = regex.exec(page.content)) {
                     var path = blah[1];
-                    var code = child_process.execSync('../../bin/python scripts/importer.py ' + path).toString();
+                    var code = child_process.execSync('python scripts/importer.py ' + path).toString();
                     page.content = page.content.replace(blah[0], "```python\n" + code + "```")
                 }
 


### PR DESCRIPTION
There is no need to relatively path to `../../bin/python`, since virtual environments already include the `python` binary in the `$PATH` environment variable.